### PR TITLE
Update multicursor.nvim's dependency

### DIFF
--- a/lua/astrocommunity/editing-support/multicursors-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/multicursors-nvim/init.lua
@@ -1,14 +1,19 @@
-return {
-  "smoka7/multicursors.nvim",
-  event = "VeryLazy",
-  dependencies = { "smoka7/hydra.nvim" },
-  opts = {},
-  keys = {
-    {
-      mode = { "v", "n" },
-      "<Leader>m",
-      "<Cmd>MCstart<CR>",
-      desc = "Create a selection for word under the cursor",
+return return {
+  {
+    "smoka7/multicursors.nvim",
+    event = "VeryLazy",
+    dependencies = {
+      "nvimtools/hydra.nvim",
+    },
+    opts = {},
+    cmd = { "MCstart", "MCvisual", "MCclear", "MCpattern", "MCvisualPattern", "MCunderCursor" },
+    keys = {
+      {
+        mode = { "v", "n" },
+        "<Leader>m",
+        "<cmd>MCstart<cr>",
+        desc = "Create a selection for selected text or word under the cursor",
+      },
     },
   },
 }


### PR DESCRIPTION
switch to `nvimtools/hydra.nvim`.

This may require the user to manually remove the old `~/.local/share/nvim/lazy/hydra.nvim` before `lazy.nvim` can detect the change and clone from `nvimtools/hydra.nvim`